### PR TITLE
Switch launch.json to lldb-dap

### DIFF
--- a/launch.json
+++ b/launch.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       "name": "unix - gui",
-      "type": "lldb",
+      "type": "lldb-dap",
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/deskflow",
@@ -14,7 +14,7 @@
     },
     {
       "name": "unix - unittests",
-      "type": "lldb",
+      "type": "lldb-dap",
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/unittests",
@@ -23,7 +23,7 @@
     },
     {
       "name": "unix - integtests",
-      "type": "lldb",
+      "type": "lldb-dap",
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/integtests",
@@ -32,7 +32,7 @@
     },
     {
       "name": "unix - server",
-      "type": "lldb",
+      "type": "lldb-dap",
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/deskflow-core",
@@ -44,7 +44,7 @@
     },
     {
       "name": "unix - client",
-      "type": "lldb",
+      "type": "lldb-dap",
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/deskflow-core",
@@ -56,7 +56,7 @@
     },
     {
       "name": "unix - daemon",
-      "type": "lldb",
+      "type": "lldb-dap",
       "cwd": "${workspaceRoot}",
       "request": "launch",
       "program": "${workspaceFolder}/build/bin/deskflow-daemon",
@@ -65,7 +65,7 @@
     },
     {
       "name": "unix - attach",
-      "type": "lldb",
+      "type": "lldb-dap",
       "request": "attach",
       "pid": "${command:pickProcess}"
     },


### PR DESCRIPTION
The "lldb" extension (which requires vadimcn.vscode-lldb) stopped working for me as it uses a bundled lldb binary that kept freezing up on launch.

This PR uses "lldb-dap" (requires llvm-vs-code-extensions.lldb-dap) which is the official llvm.org extension for VS Code. This seems to use the system lldb which is preferable.