### PR TITLE
Reccomend llvm.org extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -4,7 +4,7 @@
     "twxs.cmake",
     "llvm-vs-code-extensions.vscode-clangd",
     "ms-vscode.cpptools",
-    "vadimcn.vscode-lldb",
+    "llvm-vs-code-extensions.lldb-dap",
     "cheshirekow.cmake-format",
     "jacqueslucke.gcov-viewer"
   ]


### PR DESCRIPTION
Replace the recommendation for the LLDB extension with the llvm.org official llvm-vs-code-extensions.lldb-dap.